### PR TITLE
Put a space between "(semi-)" and "relative".  A line-break was happe…ning on the "-" instead of the ).

### DIFF
--- a/mod_cdrs.asciidoc
+++ b/mod_cdrs.asciidoc
@@ -10,7 +10,7 @@
 
 A *Charge Detail Record* is the description of a concluded charging session. The CDR is the only billing-relevant object.
 CDRs are sent from the CPO to the eMSP after the charging session has ended.
-Although there is no requirement to send CDRs in (semi-)realtime, it is seen as good practice to send them as soon as possible.
+Although there is no requirement to send CDRs in (semi-) realtime, it is seen as good practice to send them as soon as possible.
 But if there is an agreement between parties to send them, for example, once a month, that is also allowed by OCPI.
 
 [[mod_cdrs_flow_and_lifecycle]]


### PR DESCRIPTION
…ning on the "-" instead of the ).

In the PDF it looks like: "(semi-
)realtime" and that doesn't look good.  Ideally we need to just keep "(semi-)realtime" all together instead of allowing to to break.  Is there asciidoc markup for this?